### PR TITLE
Add dependency files to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# バックエンド (Rails)
+/backend/log/*
+/backend/tmp/*
+/backend/storage/*
+/backend/test/*
+/backend/public/assets
+/backend/public/packs
+/backend/public/packs-test
+/backend/node_modules
+/backend/vendor/bundle
+/backend/.bundle
+
+# フロントエンド (Nuxt.js)
+/frontend/.nuxt
+/frontend/dist
+/frontend/node_modules
+/frontend/.cache
+
+# Docker関連
+.docker
+
+# git関連
+.git
+.gitignore
+
+# ログファイル
+*.log
+
+# 環境設定ファイル
+.env
+
+# OS生成ファイル
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
.dockerignoreに以下のファイルを追加した。
・nuxt関係の依存関係ファイル
・Rails関係の依存関係ファイル
・git関係
・ログファイル
・環境設定ファイル
・OS生成ファイル